### PR TITLE
lock before calling updateProgress

### DIFF
--- a/send.go
+++ b/send.go
@@ -112,8 +112,10 @@ func (s *sender) run(ctx context.Context) error {
 }
 
 func (s *sender) updateProgress(size int, last bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.progressCurrent += size
 	if s.progressCb != nil {
-		s.progressCurrent += size
 		s.progressCb(s.progressCurrent, last)
 	}
 }


### PR DESCRIPTION
updateProgress is called from both the file walking thread and the
writing thread, and needs to lock before incrementing the bytes counter.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>