### PR TITLE
verbose progress callback for receiving

### DIFF
--- a/verbose_callback.go
+++ b/verbose_callback.go
@@ -7,6 +7,8 @@ const (
 	StatusSkipped
 	StatusSending
 	StatusSent
+	StatusReceiving
+	StatusReceived
 	StatusFailed
 )
 


### PR DESCRIPTION
This allows for a verbose callback to be registered in the receiver,
which is helpful for debugging artifacts being saved locally.

Signed-off-by: Alex Couture-Beil <alex@earthly.dev>